### PR TITLE
feat: Improve guest UX when host ends chat

### DIFF
--- a/src/app/chat-ended/page.tsx
+++ b/src/app/chat-ended/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function ChatEndedPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      router.push('/');
+    }, 5000); // 5 seconds
+
+    return () => clearTimeout(timer); // Cleanup the timer if the component unmounts
+  }, [router]);
+
+  return (
+    <div style={{ 
+      display: 'flex', 
+      flexDirection: 'column', 
+      justifyContent: 'center', 
+      alignItems: 'center', 
+      minHeight: '100vh', 
+      textAlign: 'center',
+      padding: '20px',
+      fontFamily: 'sans-serif' 
+    }}>
+      <header style={{ marginBottom: '2rem' }}>
+        <h1 style={{ fontSize: '2.5rem', color: '#333' }}>Chat Session Ended</h1>
+      </header>
+      <main>
+        <p style={{ fontSize: '1.2rem', color: '#555', lineHeight: '1.6' }}>
+          This chat session has been ended by the host. 
+          <br />
+          You will be redirected to the homepage shortly.
+        </p>
+      </main>
+      <footer style={{ marginTop: '3rem', fontSize: '0.9rem', color: '#777' }}>
+        <p>If you are not redirected automatically, please <a href="/" style={{ color: '#0070f3', textDecoration: 'none' }}>click here</a>.</p>
+      </footer>
+    </div>
+  );
+}


### PR DESCRIPTION
This commit implements changes to the guest-side chat interface when the host ends a chat session.

Key changes:
- When the host ends the chat, your chat interface will now display a "Chat session has ended" message.
- After 5 seconds, the chat messages are cleared from your view.
- You are then automatically redirected to a new static page `/chat-ended`.
- The `/chat-ended` page informs you that the chat was ended by the host and then automatically redirects you to the homepage after another 5 seconds.

This addresses the issue where the guest side previously did not visually update or redirect when a chat was terminated by the host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated page that informs users when a chat session has ended, with automatic redirection to the homepage after a short delay and a manual link as a fallback.
  - Implemented automatic cleanup and navigation for non-host users when a chat session ends, redirecting them to the chat-ended page after a brief delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->