### PR TITLE
I've implemented a graceful "End Chat" flow.

### DIFF
--- a/src/app/api/end-chat-session/route.ts
+++ b/src/app/api/end-chat-session/route.ts
@@ -1,0 +1,47 @@
+import { supabase } from '@/utils/supabase';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { chatId } = body;
+
+    if (!chatId || typeof chatId !== 'string') {
+      return NextResponse.json({ error: 'chatId is required and must be a string' }, { status: 400 });
+    }
+
+    // 1. Mark the chat session as inactive
+    const { error: sessionError } = await supabase
+      .from('chat_sessions')
+      .update({ is_active: false, ended_at: new Date().toISOString() })
+      .eq('chat_id', chatId);
+
+    if (sessionError) {
+      console.error('Error updating chat session to inactive:', sessionError);
+      return NextResponse.json({ error: 'Failed to end chat session', details: sessionError.message }, { status: 500 });
+    }
+
+    // 2. Permanently delete chat messages for the given chatId
+    const { error: messagesError } = await supabase
+      .from('temporary_chat_messages')
+      .delete()
+      .eq('chat_id', chatId);
+
+    if (messagesError) {
+      console.error('Error deleting chat messages:', messagesError);
+      // If updating session was OK, but message deletion failed, this is a partial success.
+      // Depending on desired atomicity, might need to decide how to respond.
+      // For now, let's report the message deletion error if it occurs.
+      return NextResponse.json({ error: 'Failed to delete chat messages', details: messagesError.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ message: 'Chat session ended and messages deleted successfully' }, { status: 200 });
+
+  } catch (error: any) {
+    console.error('Error in end-chat-session handler:', error);
+    if (error.name === 'SyntaxError' || (error.type && error.type === 'entity.parse.failed')) { // Handle JSON parsing errors
+        return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+    return NextResponse.json({ error: 'An unexpected error occurred' }, { status: 500 });
+  }
+}

--- a/src/app/chat-ended/page.tsx
+++ b/src/app/chat-ended/page.tsx
@@ -1,0 +1,32 @@
+'use client'; // Good practice for simple static pages, though not strictly necessary if no client hooks
+
+import React from 'react';
+// Optional: If you have a standard page layout component, import and use it.
+// import PageLayout from '@/components/layout/PageLayout'; 
+
+const ChatEndedPage = () => {
+  return (
+    // If using a PageLayout, wrap content with it.
+    // <PageLayout title="Chat Ended">
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4 text-center">
+      <div className="bg-white p-8 rounded-lg shadow-md max-w-md w-full">
+        <h1 className="text-2xl font-semibold text-gray-800 mb-4">
+          Chat Session Ended
+        </h1>
+        <p className="text-gray-600">
+          This chat has ended. Please await a new invitation to start another conversation.
+        </p>
+        {/* Optional: Add a button to navigate to the homepage or login page */}
+        {/* <button
+          onClick={() => window.location.href = '/'}
+          className="mt-6 px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700 transition-colors"
+        >
+          Go to Homepage
+        </button> */}
+      </div>
+    </div>
+    // </PageLayout>
+  );
+};
+
+export default ChatEndedPage;

--- a/src/components/chat/EndChatModal.tsx
+++ b/src/components/chat/EndChatModal.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { cn } from '@/utils/cn';
+
+interface EndChatModalProps {
+  isOpen: boolean;
+  actor: 'host' | 'guest' | null;
+  countdown: number;
+  onClose: () => void; // Included as per spec, even if not directly used by user action on this modal
+}
+
+const EndChatModal: React.FC<EndChatModalProps> = ({
+  isOpen,
+  actor,
+  countdown,
+  onClose,
+}) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  let headline = '';
+  if (actor === 'host') {
+    headline = 'This chat has been ended by the host.';
+  } else if (actor === 'guest') {
+    headline = 'This chat has been ended by the guest.';
+  } else {
+    headline = 'This chat has ended.'; // Generic fallback
+  }
+
+  return (
+    <div
+      // Overlay: fixed, full screen, semi-transparent background
+      className={cn(
+        'fixed inset-0 z-50 flex items-center justify-center bg-black/50 transition-opacity duration-300',
+        isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
+      )}
+      // onClick={onClose} // Deliberately not adding onClose to overlay for "no backdrop click-through"
+    >
+      <div
+        // Modal content: styled similarly to CueCard, but explicitly not allowing click propagation to overlay
+        onClick={(e) => e.stopPropagation()}
+        className={cn(
+          'bg-neutral-50/90 dark:bg-neutral-900/90 backdrop-blur-lg p-6 sm:p-8 rounded-3xl shadow-xl dark:shadow-neutral-800/50',
+          'transform transition-all duration-300 ease-out',
+          'w-full max-w-md mx-4', // Responsive width
+          isOpen ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
+        )}
+      >
+        <h3 className="text-xl sm:text-2xl font-semibold text-neutral-900 dark:text-neutral-50 mb-4 text-center">
+          {headline}
+        </h3>
+        <div className="text-center mb-6">
+          <p className="text-7xl font-bold text-neutral-900 dark:text-neutral-50">
+            {countdown}
+          </p>
+        </div>
+        <p className="text-neutral-600 dark:text-neutral-400 text-sm sm:text-base leading-relaxed text-center">
+          Chat history will be permanently deleted in {countdown} second{countdown === 1 ? '' : 's'}.
+        </p>
+        {/* No close button as per current requirements. 
+            If a close button were needed, it would call onClose.
+            e.g., <button onClick={onClose}>Close</button> 
+        */}
+      </div>
+    </div>
+  );
+};
+
+export default EndChatModal;

--- a/src/hooks/useEndChat.ts
+++ b/src/hooks/useEndChat.ts
@@ -1,0 +1,216 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/utils/supabase'; // Assuming this is the configured Supabase client
+import { RealtimeChannel } from '@supabase/supabase-js';
+import { useChat } from '@/context/ChatProvider'; // Added for ChatContext access
+
+type EndReason = 'host' | 'guest';
+type CurrentUserRole = 'host' | 'guest';
+
+interface UseEndChatReturn {
+  isModalOpen: boolean;
+  countdown: number;
+  endReason: EndReason | null;
+  isEnding: boolean;
+  endChat: (reason: EndReason, currentChatId: string) => void;
+  handleIncomingEndChatEvent: (
+    payload: { reason: EndReason; chatId: string },
+    currentChatId: string,
+    currentUserRole: CurrentUserRole
+  ) => void;
+}
+
+const COUNTDOWN_INITIAL = 5;
+
+export const useEndChat = (currentUserRole: CurrentUserRole): UseEndChatReturn => {
+  const { receivedEndChatEvent, clearReceivedEndChatEvent, activeChatSessionId } = useChat();
+
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [countdown, setCountdown] = useState<number>(COUNTDOWN_INITIAL);
+  const [endReason, setEndReason] = useState<EndReason | null>(null);
+  const [isEnding, setIsEnding] = useState<boolean>(false);
+
+  const router = useRouter();
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  // channelRef is no longer needed for the broadcast channel as its lifecycle is self-contained in endChat.
+
+  const clearTimer = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  const startCountdown = useCallback((onComplete: () => void) => {
+    clearTimer();
+    setCountdown(COUNTDOWN_INITIAL);
+    setIsModalOpen(true);
+    intervalRef.current = setInterval(() => {
+      setCountdown((prevCountdown) => {
+        if (prevCountdown <= 1) {
+          clearTimer();
+          onComplete();
+          return 0;
+        }
+        return prevCountdown - 1;
+      });
+    }, 1000);
+  }, [clearTimer]);
+
+  const endChat = useCallback(async (reason: EndReason, currentChatId: string) => {
+    if (isEnding) return;
+
+    setIsEnding(true);
+    setEndReason(reason);
+    // Modal is opened by startCountdown
+
+    if (supabase) {
+      const channelName = `realtime-chat-${currentChatId}`;
+      // Create a new channel instance for sending this event.
+      // Important: This instance is temporary and specific to this send operation.
+      const tempChannel = supabase.channel(channelName, {
+        config: {
+          broadcast: {
+            ack: true, // As per new requirement for channel management
+            // self: false, // Generally good, but ChatProvider might need to see its own for some reason (unlikely for chat:end)
+                         // If ChatProvider is already subscribed and handles its own events, this is fine.
+                         // The main thing is that `useEndChat` doesn't also trigger its own `handleIncomingEndChatEvent` from its own send.
+                         // The `isEnding` flag in `handleIncomingEndChatEvent` should prevent self-triggering issues.
+          },
+        },
+      });
+
+      tempChannel.subscribe(async (status) => {
+        if (status === 'SUBSCRIBED') {
+          try {
+            await tempChannel.send({
+              type: 'broadcast',
+              event: 'chat:end',
+              payload: { reason, chatId: currentChatId },
+            });
+            console.log(`[useEndChat] Sent "chat:end" event on ${channelName}`);
+          } catch (error) {
+            console.error(`[useEndChat] Error sending "chat:end" event on ${channelName}:`, error);
+          } finally {
+            // Immediately unsubscribe and remove this temporary channel instance
+            // to avoid conflicts or duplicate handlers with ChatProvider's persistent channel.
+            supabase.removeChannel(tempChannel);
+            console.log(`[useEndChat] Removed temporary channel instance ${channelName} after sending.`);
+          }
+        } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT' || status === 'CLOSED') {
+          console.error(`[useEndChat] Channel error for ${channelName} before sending "chat:end": ${status}.`);
+          // Attempt to remove the channel to clean up
+          supabase.removeChannel(tempChannel);
+          console.log(`[useEndChat] Removed temporary channel instance ${channelName} due to error.`);
+        }
+      });
+    } else {
+      console.warn('[useEndChat] Supabase client not available for sending chat:end event.');
+    }
+
+    startCountdown(() => {
+      // Post-countdown actions for initiator
+      fetch('/api/end-chat-session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chatId: currentChatId }),
+      })
+      .then(async res => {
+        if (!res.ok) {
+          const errorData = await res.json().catch(() => ({})); // Catch if res.json() fails
+          console.error('API call to /api/end-chat-session failed:', res.status, errorData);
+          // Potentially handle error, e.g. show a notification to the user
+        } else {
+          console.log('/api/end-chat-session call successful');
+        }
+      })
+      .catch(error => {
+        console.error('Error calling /api/end-chat-session:', error);
+      })
+      .finally(() => {
+        // Role-specific redirects for the initiator
+        if (reason === 'host') {
+          router.push('/');
+        } else if (reason === 'guest') {
+          router.push('/chat-ended');
+        }
+        setIsModalOpen(false); // Or let redirect handle unmount
+        setIsEnding(false);
+        setEndReason(null);
+        setCountdown(COUNTDOWN_INITIAL); // Reset countdown for potential next use
+      });
+    });
+  }, [isEnding, router, startCountdown, clearTimer]);
+
+
+  const handleIncomingEndChatEvent = useCallback((
+    payload: { reason: EndReason; chatId: string },
+    currentChatId: string,
+    currentUserRole: CurrentUserRole
+  ) => {
+    if (payload.chatId !== currentChatId || isEnding) {
+      return;
+    }
+
+    setIsEnding(true);
+    setEndReason(payload.reason);
+    // Modal is opened by startCountdown
+
+    startCountdown(() => {
+      // Post-countdown actions for receiver
+      // API call is NOT made by the receiver as per design.
+      if (currentUserRole === 'host') {
+        router.push('/');
+      } else if (currentUserRole === 'guest') {
+        router.push('/chat-ended');
+      }
+      setIsModalOpen(false); // Or let redirect handle unmount
+      setIsEnding(false);
+      setEndReason(null);
+      setCountdown(COUNTDOWN_INITIAL); // Reset countdown
+    });
+  }, [isEnding, router, startCountdown, clearTimer]); // Dependencies seem correct
+
+  // Effect to handle incoming chat end events from ChatContext
+  useEffect(() => {
+    if (
+      receivedEndChatEvent &&
+      activeChatSessionId &&
+      receivedEndChatEvent.chatId === activeChatSessionId
+    ) {
+      console.log('[useEndChat] Detected receivedEndChatEvent from context:', receivedEndChatEvent);
+      // The handleIncomingEndChatEvent function is responsible for checking isEnding
+      handleIncomingEndChatEvent(
+        receivedEndChatEvent,
+        activeChatSessionId,
+        currentUserRole
+      );
+      clearReceivedEndChatEvent(); // Reset the event in ChatContext
+    }
+  }, [
+    receivedEndChatEvent,
+    clearReceivedEndChatEvent,
+    activeChatSessionId,
+    currentUserRole,
+    handleIncomingEndChatEvent, // handleIncomingEndChatEvent is memoized with useCallback
+  ]);
+
+  // Cleanup interval on unmount
+  useEffect(() => {
+    return () => {
+      clearTimer();
+      // channelRef.current is no longer used for the broadcast channel,
+      // as its lifecycle is self-contained within the endChat function.
+      // If channelRef were used for other persistent subscriptions by this hook, that cleanup would remain.
+    };
+  }, [clearTimer]);
+
+  return {
+    isModalOpen,
+    countdown,
+    endReason,
+    isEnding,
+    endChat,
+    handleIncomingEndChatEvent,
+  };
+};


### PR DESCRIPTION
This update introduces a comprehensive "End Chat" functionality for your real-time chat application.

Key changes include:

1.  **EndChatModal Component:** I've added a new modal (`src/components/chat/EndChatModal.tsx`) that displays a countdown and messages when a chat is ended by either the host or guest.

2.  **useEndChat Hook:** I created a custom hook (`src/hooks/useEndChat.ts`) to encapsulate the core logic:
    *   It manages modal visibility, a 5-second countdown, and the reason for ending.
    *   It provides an `endChat` function for the initiator:
        *   This sends a "chat:end" Supabase Realtime event.
        *   It triggers an API call to `/api/end-chat-session` for data deletion post-countdown.
        *   It handles role-specific redirects (host to `/`, guest to `/chat-ended`).
    *   It provides `handleIncomingEndChatEvent` for the receiver, initiating the modal/countdown and redirects without a duplicate API call.
    *   It includes cleanup for timers and listeners.

3.  **ChatInterface Updates:**
    *   I integrated `useEndChat`, passing your role.
    *   I made the "End Chat" button available to both host and guest.
    *   I made sure `EndChatModal` renders and inputs are disabled during the end-chat sequence.

4.  **ChatProvider Updates:**
    *   It now listens for the "chat:end" broadcast event on the existing chat channel.
    *   It exposes the received event payload via context, enabling `useEndChat` to react to remote-initiated end-chat events.

5.  **API Route (`/api/end-chat-session/route.ts`):**
    *   This handles `POST` requests to soft-delete the chat session (sets `is_active=false` in `chat_sessions`).
    *   It permanently deletes associated messages from `temporary_chat_messages`.

6.  **Static Page (`/chat-ended/page.tsx`):**
    *   I added a new page where guests are redirected after a chat ends, displaying an appropriate message.

This implementation ensures that chat inputs are disabled during the countdown, timers are cleaned up, and the experience is consistent for both host and guest, fulfilling the specified acceptance criteria for the graceful end chat flow. I also addressed channel name consistency between sender and listener for the "chat:end" event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a modal dialog that displays a countdown and clear messaging when a chat session is ended by either participant.
  - Added real-time chat ending functionality, ensuring both users are notified and redirected appropriately when a chat is ended.
  - Implemented a dedicated page to inform users when a chat session has concluded.
  - Enhanced the chat interface to prevent further interaction during the chat ending process.

- **Bug Fixes**
  - Disabled message input and action buttons during the chat ending process to prevent unintended interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->